### PR TITLE
Make Settings app search for all backgrounds recursively

### DIFF
--- a/src/background.cpp
+++ b/src/background.cpp
@@ -4,7 +4,7 @@
 static QVariantList getBackgroundPaths()
 {
     QVariantList list;
-    QDirIterator it("/usr/share/backgrounds/cutefishos", QStringList() << "*.jpg" << "*.png", QDir::Files, QDirIterator::Subdirectories);
+    QDirIterator it("/usr/share/backgrounds/", QStringList() << "*.jpg" << "*.png", QDir::Files, QDirIterator::Subdirectories);
     while (it.hasNext()) {
         QString bg = it.next();
         list.append(QVariant(bg));


### PR DESCRIPTION
At the moment, Cutefish will only search for backgrounds in its respective backgrounds subdirectory in `/usr/share/backgrounds`

This causes problems with you and me who downloads custom backgrounds as packages that put them in said directory.

This simple change causes a recursive search in the upper directory so it will search for *all* backgrounds included in `/usr/share/backgrounds`