### PR TITLE
Add flag CMAKE_INSTALL_PREFIX for translation and desktop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,8 +104,8 @@ install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(FILES
     cutefish-settings.desktop
-    DESTINATION /usr/share/applications/
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/usr/share/applications/
     COMPONENT Runtime
 )
 
-install(FILES ${QM_FILES} DESTINATION /usr/share/${PROJECT_NAME}/translations)
+install(FILES ${QM_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX}/usr/share/${PROJECT_NAME}/translations)


### PR DESCRIPTION
This flag is very useful for developers and packagers.

Although the flag -DCMAKE_INSTALL_PREFIX has been passed in the shell,
it is not used in the installation of ‘’.desktop’’ and ‘translation’’.

By explicitly setting CMAKE_INSTALL_PREFIX,
this will make'make' the correct installation file to the specified directory.