### PR TITLE
Fix no version show on other distro

### DIFF
--- a/src/about.cpp
+++ b/src/about.cpp
@@ -90,8 +90,11 @@ bool About::isCutefishOS()
 
 QString About::version()
 {
-    QSettings settings("/etc/cutefish", QSettings::IniFormat);
-    return settings.value("Version").toString();
+    if (this->isCutefishOS()) {
+        QSettings settings("/etc/cutefish", QSettings::IniFormat);
+        return settings.value("Version").toString();
+    }
+    return this->prettyProductName();
 }
 
 QString About::osName()


### PR DESCRIPTION
There is no `/etc/cutefish` file in some distro, this patch fixed the blank version.