### PR TITLE
Fix missing ${CMAKE_SOURCE_DIR} in qt5_create_translation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 file(GLOB TS_FILES translations/*.ts)
-qt5_create_translation(QM_FILES ${TS_FILES})
+qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES})
 add_custom_target(translations DEPENDS ${QM_FILES} SOURCES ${TS_FILES})
 add_dependencies(${PROJECT_NAME} translations)
 


### PR DESCRIPTION
Fixes the following build failures:

```
[  1%] Generating .lupdate/translations/ar_AA.ts.stamp
QFSFileEngine::open: No file name specified
lupdate error: List file '' is not readable.
make[2]: *** [CMakeFiles/translations.dir/build.make:312: .lupdate/translations/ar_AA.ts.stamp] Error 1
make[1]: *** [CMakeFiles/Makefile2:193: CMakeFiles/translations.dir/all] Error 2
```